### PR TITLE
Redefine vars with scope out of try-catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const Discord = require('discord.js');
 const chalk = require('chalk');
 
 
-
 // run main function
 startBot();
 
@@ -80,7 +79,9 @@ function startBot()
         //Executes when bot spawns
         bot.once('spawn', () => {
             try{
+                if(sendToDS){
                 const channel = client.channels.cache.get(announcements.discordBot.channelID)
+                }
             }catch(err){
                 console.log(`Something went wrong with your channel id.
                 Some things to make sure:

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ function startBot()
             };
     
 
-            //why is once used here
+           
             //Runs when health or Hp change and sends a message in Discord
             bot.once('health', () => {
                 const startEmbed = new Discord.MessageEmbed()


### PR DESCRIPTION
I defined the vars that are set in the try-catch outside of the try-catch so they can be accessed outside the try-catch scope.


Also found an error if the bot is killed in one hit, it errors out if thats the first attack. 

line 310 isnt defined in time when line 284 attempts to use it

the respawn event attempts to add the value to the embed, but it isnt defined so it crashes